### PR TITLE
Add password encoding and login verification

### DIFF
--- a/src/main/java/com/roommatey/config/SecurityConfig.java
+++ b/src/main/java/com/roommatey/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,5 +23,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable); //
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/roommatey/controller/UserController.java
+++ b/src/main/java/com/roommatey/controller/UserController.java
@@ -7,6 +7,7 @@ import com.roommatey.repository.UserRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -16,10 +17,12 @@ public class UserController {
 
     private final UserRepository userRepo;
     private final HouseholdRepository householdRepo;
+    private final PasswordEncoder passwordEncoder;
 
-    public UserController(UserRepository userRepo, HouseholdRepository householdRepo) {
+    public UserController(UserRepository userRepo, HouseholdRepository householdRepo, PasswordEncoder passwordEncoder) {
         this.userRepo = userRepo;
         this.householdRepo = householdRepo;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @PostMapping("/register")
@@ -29,6 +32,7 @@ public class UserController {
             return "redirect:/household/create"; // fallback
         }
         user.setHousehold(household);
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
         userRepo.save(user);
         return "redirect:/users/registered";
     }
@@ -75,6 +79,9 @@ public class UserController {
         if (user.getHousehold() == null) {
             user.setHousehold(household);
         }
+        if (user.getPassword() != null) {
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+        }
         userRepo.save(user);
         return "redirect:/users/manage";
     }
@@ -83,6 +90,22 @@ public class UserController {
     public String deleteUser(@PathVariable Long id) {
         userRepo.deleteById(id);
         return "redirect:/users/manage";
+    }
+
+    @GetMapping("/login")
+    public String loginForm(Model model) {
+        model.addAttribute("error", null);
+        return "user-login";
+    }
+
+    @PostMapping("/login")
+    public String login(@RequestParam String phone, @RequestParam String password, Model model) {
+        User user = userRepo.findByPhoneNumber(phone);
+        if (user != null && passwordEncoder.matches(password, user.getPassword())) {
+            return "redirect:/";
+        }
+        model.addAttribute("error", "Invalid phone number or password");
+        return "user-login";
     }
 
 

--- a/src/main/java/com/roommatey/model/User.java
+++ b/src/main/java/com/roommatey/model/User.java
@@ -29,7 +29,7 @@ public class User {
     public void setName(String name) { this.name = name; }
 
     public String getPhone() { return phoneNumber; }
-    public void setEmail(String email) { this.phoneNumber = email; }
+    public void setPhone(String phone) { this.phoneNumber = phone; }
 
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }

--- a/src/main/java/com/roommatey/repository/UserRepository.java
+++ b/src/main/java/com/roommatey/repository/UserRepository.java
@@ -4,5 +4,5 @@ import com.roommatey.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByphoneNumber(String phoneNumber);
+    User findByPhoneNumber(String phoneNumber);
 }

--- a/src/main/resources/templates/user-login.html
+++ b/src/main/resources/templates/user-login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:if="${error}" class="alert alert-danger" role="alert">
+    <p th:text="${error}"></p>
+</div>
+<div th:replace="~{fragments/navbar :: navbar}"></div>
+<div class="container mt-5">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h2 class="card-title">Login</h2>
+            <form th:action="@{/users/login}" method="post">
+                <div class="mb-3">
+                    <label for="phone" class="form-label">Phone Number</label>
+                    <input type="text" name="phone" class="form-control" id="phone" required>
+                </div>
+                <div class="mb-3">
+                    <label for="password" class="form-label">Password</label>
+                    <input type="password" name="password" class="form-control" id="password" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Login</button>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add BCrypt PasswordEncoder bean in security configuration
- encode user passwords on registration and update
- verify hashed passwords on login with new form

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e59e1162c8322bdff8ad77ea48512